### PR TITLE
Support /etc/synology.options

### DIFF
--- a/src/scripts/installer.sh
+++ b/src/scripts/installer.sh
@@ -101,7 +101,7 @@ postinst ()
     fi
 
     #start subsonic as subsonic user
-    su - subsonic -s /bin/sh -c /usr/syno/synoman/webman/3rdparty/subsonic/subsonic.sh
+    su - subsonic -s /bin/sh -c "/usr/syno/synoman/webman/3rdparty/subsonic/subsonic.sh $(cat /etc/synology.options 2>&1 || true)"
 
     sleep 10
     

--- a/src/scripts/start-stop-status
+++ b/src/scripts/start-stop-status
@@ -51,7 +51,7 @@ case "$1" in
 	  fi
 	  # starting subsonic as subsonic daemon user
 	  echo "$(date +%d.%m.%y_%H:%M:%S): starting subsonic as subsonic daemon user" >> ${SYNOPKG_PKGDEST}/subsonic_package.log
-      su - subsonic -s /bin/sh -c /usr/syno/synoman/webman/3rdparty/subsonic/subsonic.sh
+      su - subsonic -s /bin/sh -c "/usr/syno/synoman/webman/3rdparty/subsonic/subsonic.sh $(cat /etc/synology.options 2>&1 || true)"
       sleep 10
 	  echo "$(date +%d.%m.%y_%H:%M:%S): started subsonic as subsonic daemon user" >> ${SYNOPKG_PKGDEST}/subsonic_package.log
 	  subsonic_get_pid


### PR DESCRIPTION
The contents of this single-line file will be passed to subsonic.sh.

A good reason to use it is if you want to pass `--db=` to the script to use a better SQL db.